### PR TITLE
Fix arn partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Available targets:
 | [aws_iam_policy_document.assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_log_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_ssm_parameter.api_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -58,6 +58,7 @@
 | [aws_iam_policy_document.assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_log_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_ssm_parameter.api_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -68,7 +68,7 @@ resource "aws_lambda_permission" "allow_s3_bucket" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.forwarder_log[0].arn
   principal     = "s3.amazonaws.com"
-  source_arn    = "arn:aws:s3:::${each.value}"
+  source_arn    = "${local.arn_format}:s3:::${each.value}"
 }
 
 resource "aws_s3_bucket_notification" "s3_bucket_notification" {
@@ -95,7 +95,7 @@ data "aws_iam_policy_document" "s3_log_bucket" {
       "s3:ListBucket",
       "s3:ListObjects",
     ]
-    resources = concat(formatlist("arn:aws:s3:::%s", var.s3_buckets), formatlist("arn:aws:s3:::%s/*", var.s3_buckets))
+    resources = concat(formatlist("%s:s3:::%s", local.arn_format, var.s3_buckets), formatlist("%s:s3:::%s/*", local.arn_format, var.s3_buckets))
   }
 
   dynamic "statement" {
@@ -144,7 +144,7 @@ resource "aws_lambda_permission" "cloudwatch_groups" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.forwarder_log[0].function_name
   principal     = "logs.${local.aws_region}.amazonaws.com"
-  source_arn    = "arn:aws:logs:${local.aws_region}:${local.aws_account_id}:log-group:${each.value}:*"
+  source_arn    = "${local.arn_format}:logs:${local.aws_region}:${local.aws_account_id}:log-group:${each.value}:*"
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_log_subscription_filter" {

--- a/lambda-rds.tf
+++ b/lambda-rds.tf
@@ -75,7 +75,7 @@ resource "aws_lambda_permission" "cloudwatch_enhance_rds" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.forwarder_rds[0].function_name
   principal     = "logs.amazonaws.com"
-  source_arn    = "arn:aws:logs:${local.aws_region}:${local.aws_account_id}:log-group:RDSOSMetrics:*"
+  source_arn    = "${local.arn_format}:logs:${local.aws_region}:${local.aws_account_id}:log-group:RDSOSMetrics:*"
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "datadog_log_subscription_filter_rds" {

--- a/lambda-vpc-logs.tf
+++ b/lambda-vpc-logs.tf
@@ -76,7 +76,7 @@ resource "aws_lambda_permission" "cloudwatch_vpclogs" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.forwarder_vpclogs[0].function_name
   principal     = "logs.amazonaws.com"
-  source_arn    = "arn:aws:logs:${local.aws_region}:${local.aws_account_id}:log-group:${var.vpclogs_cloudwatch_log_group}:*"
+  source_arn    = "${local.arn_format}:logs:${local.aws_region}:${local.aws_account_id}:log-group:${var.vpclogs_cloudwatch_log_group}:*"
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "datadog_log_subscription_filter_vpclogs" {

--- a/main.tf
+++ b/main.tf
@@ -2,12 +2,17 @@ data "aws_caller_identity" "current" {
   count = local.enabled ? 1 : 0
 }
 
+data "aws_partition" "current" {
+  count = local.enabled ? 1 : 0
+}
+
 data "aws_region" "current" {
   count = local.enabled ? 1 : 0
 }
 
 locals {
   enabled               = module.this.enabled
+  arn_format            = "arn:${data.aws_partition.current[0].partition}"
   aws_account_id        = join("", data.aws_caller_identity.current.*.account_id)
   aws_region            = join("", data.aws_region.current.*.name)
   lambda_enabled        = local.enabled


### PR DESCRIPTION
## what
* Lookup arn partition instead of hardcoding it so module will work in govcloud

## why
* govcloud

## references
* Fixes https://github.com/cloudposse/terraform-aws-datadog-lambda-forwarder/issues/8

Note, I was only able to test the functionality provide by lambda-log.tf and lambda-vpc-logs.tf

