### PR TITLE
Use data source to verify log groups in plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,12 +207,12 @@ Available targets:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_forwarder_log_artifact"></a> [forwarder\_log\_artifact](#module\_forwarder\_log\_artifact) | cloudposse/module-artifact/external | 0.7.0 |
+| <a name="module_forwarder_log_artifact"></a> [forwarder\_log\_artifact](#module\_forwarder\_log\_artifact) | cloudposse/module-artifact/external | 0.7.1 |
 | <a name="module_forwarder_log_label"></a> [forwarder\_log\_label](#module\_forwarder\_log\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_forwarder_log_s3_label"></a> [forwarder\_log\_s3\_label](#module\_forwarder\_log\_s3\_label) | cloudposse/label/null | 0.25.0 |
-| <a name="module_forwarder_rds_artifact"></a> [forwarder\_rds\_artifact](#module\_forwarder\_rds\_artifact) | cloudposse/module-artifact/external | 0.7.0 |
+| <a name="module_forwarder_rds_artifact"></a> [forwarder\_rds\_artifact](#module\_forwarder\_rds\_artifact) | cloudposse/module-artifact/external | 0.7.1 |
 | <a name="module_forwarder_rds_label"></a> [forwarder\_rds\_label](#module\_forwarder\_rds\_label) | cloudposse/label/null | 0.25.0 |
-| <a name="module_forwarder_vpclogs_artifact"></a> [forwarder\_vpclogs\_artifact](#module\_forwarder\_vpclogs\_artifact) | cloudposse/module-artifact/external | 0.7.0 |
+| <a name="module_forwarder_vpclogs_artifact"></a> [forwarder\_vpclogs\_artifact](#module\_forwarder\_vpclogs\_artifact) | cloudposse/module-artifact/external | 0.7.1 |
 | <a name="module_forwarder_vpclogs_label"></a> [forwarder\_vpclogs\_label](#module\_forwarder\_vpclogs\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Available targets:
 | [archive_file.forwarder_rds](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [archive_file.forwarder_vpclogs](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_cloudwatch_log_group.cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lambda_default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_log_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,12 +18,12 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_forwarder_log_artifact"></a> [forwarder\_log\_artifact](#module\_forwarder\_log\_artifact) | cloudposse/module-artifact/external | 0.7.0 |
+| <a name="module_forwarder_log_artifact"></a> [forwarder\_log\_artifact](#module\_forwarder\_log\_artifact) | cloudposse/module-artifact/external | 0.7.1 |
 | <a name="module_forwarder_log_label"></a> [forwarder\_log\_label](#module\_forwarder\_log\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_forwarder_log_s3_label"></a> [forwarder\_log\_s3\_label](#module\_forwarder\_log\_s3\_label) | cloudposse/label/null | 0.25.0 |
-| <a name="module_forwarder_rds_artifact"></a> [forwarder\_rds\_artifact](#module\_forwarder\_rds\_artifact) | cloudposse/module-artifact/external | 0.7.0 |
+| <a name="module_forwarder_rds_artifact"></a> [forwarder\_rds\_artifact](#module\_forwarder\_rds\_artifact) | cloudposse/module-artifact/external | 0.7.1 |
 | <a name="module_forwarder_rds_label"></a> [forwarder\_rds\_label](#module\_forwarder\_rds\_label) | cloudposse/label/null | 0.25.0 |
-| <a name="module_forwarder_vpclogs_artifact"></a> [forwarder\_vpclogs\_artifact](#module\_forwarder\_vpclogs\_artifact) | cloudposse/module-artifact/external | 0.7.0 |
+| <a name="module_forwarder_vpclogs_artifact"></a> [forwarder\_vpclogs\_artifact](#module\_forwarder\_vpclogs\_artifact) | cloudposse/module-artifact/external | 0.7.1 |
 | <a name="module_forwarder_vpclogs_label"></a> [forwarder\_vpclogs\_label](#module\_forwarder\_vpclogs\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -59,6 +59,7 @@
 | [archive_file.forwarder_rds](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [archive_file.forwarder_vpclogs](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_cloudwatch_log_group.cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lambda_default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_log_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -4,7 +4,7 @@
 # Refer to the table here https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/?tab=awsconsole#automatically-set-up-triggers
 
 locals {
-  s3_logs_enabled = local.lambda_enabled && var.forwarder_log_enabled && var.s3_buckets != null ? true : false
+  s3_logs_enabled = local.lambda_enabled && var.forwarder_log_enabled && var.s3_buckets != null
 
   forwarder_log_artifact_url = var.forwarder_log_artifact_url != null ? var.forwarder_log_artifact_url : (
     "https://github.com/DataDog/datadog-serverless-functions/releases/download/aws-dd-forwarder-${var.dd_forwarder_version}/${var.dd_artifact_filename}-${var.dd_forwarder_version}.zip"
@@ -196,6 +196,12 @@ resource "aws_lambda_permission" "cloudwatch_groups" {
   source_arn    = "${local.arn_format}:logs:${local.aws_region}:${local.aws_account_id}:log-group:${each.value.name}:*"
 }
 
+data "aws_cloudwatch_log_group" "cloudwatch_log_group" {
+  for_each = local.lambda_enabled && var.forwarder_log_enabled ? var.cloudwatch_forwarder_log_groups : {}
+  
+  name = each.value.name
+}
+
 resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_log_subscription_filter" {
   for_each = local.lambda_enabled && var.forwarder_log_enabled ? var.cloudwatch_forwarder_log_groups : {}
 
@@ -203,4 +209,6 @@ resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_log_subscription_f
   log_group_name  = each.value.name
   destination_arn = aws_lambda_function.forwarder_log[0].arn
   filter_pattern  = each.value.filter_pattern
+
+  depends_on = [data.aws_cloudwatch_log_group]
 }

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -206,7 +206,7 @@ resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_log_subscription_f
   for_each = local.lambda_enabled && var.forwarder_log_enabled ? var.cloudwatch_forwarder_log_groups : {}
 
   name            = module.forwarder_log_label.id
-  log_group_name  = data.aws_cloudwatch_log_group.cloudwatch_log_group[each.value.name].name
+  log_group_name  = data.aws_cloudwatch_log_group.cloudwatch_log_group[each.key].name
   destination_arn = aws_lambda_function.forwarder_log[0].arn
-  filter_pattern  = var.cloudwatch_forwarder_log_groups[each.value.name].filter_pattern
+  filter_pattern  = var.cloudwatch_forwarder_log_groups[each.key].filter_pattern
 }

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -36,7 +36,7 @@ module "forwarder_log_s3_label" {
 module "forwarder_log_artifact" {
   count   = local.lambda_enabled && var.forwarder_log_enabled ? 1 : 0
   source  = "cloudposse/module-artifact/external"
-  version = "0.7.0"
+  version = "0.7.1"
 
   filename    = "forwarder-log.zip"
   module_name = var.dd_module_name

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -198,7 +198,7 @@ resource "aws_lambda_permission" "cloudwatch_groups" {
 
 data "aws_cloudwatch_log_group" "cloudwatch_log_group" {
   for_each = local.lambda_enabled && var.forwarder_log_enabled ? var.cloudwatch_forwarder_log_groups : {}
-  
+
   name = each.value.name
 }
 

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -203,12 +203,10 @@ data "aws_cloudwatch_log_group" "cloudwatch_log_group" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_log_subscription_filter" {
-  for_each = local.lambda_enabled && var.forwarder_log_enabled ? var.cloudwatch_forwarder_log_groups : {}
+  for_each = data.aws_cloudwatch_log_group.cloudwatch_log_group
 
   name            = module.forwarder_log_label.id
   log_group_name  = each.value.name
   destination_arn = aws_lambda_function.forwarder_log[0].arn
-  filter_pattern  = each.value.filter_pattern
-
-  depends_on = [data.aws_cloudwatch_log_group]
+  filter_pattern  = var.cloudwatch_forwarder_log_groups[each.value.name]
 }

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -203,10 +203,10 @@ data "aws_cloudwatch_log_group" "cloudwatch_log_group" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_log_subscription_filter" {
-  for_each = data.aws_cloudwatch_log_group.cloudwatch_log_group
+  for_each = local.lambda_enabled && var.forwarder_log_enabled ? var.cloudwatch_forwarder_log_groups : {}
 
   name            = module.forwarder_log_label.id
-  log_group_name  = each.value.name
+  log_group_name  = data.aws_cloudwatch_log_group.cloudwatch_log_group[each.value.name].name
   destination_arn = aws_lambda_function.forwarder_log[0].arn
-  filter_pattern  = var.cloudwatch_forwarder_log_groups[each.value.name]
+  filter_pattern  = var.cloudwatch_forwarder_log_groups[each.value.name].filter_pattern
 }

--- a/lambda-rds.tf
+++ b/lambda-rds.tf
@@ -23,7 +23,7 @@ module "forwarder_rds_label" {
 module "forwarder_rds_artifact" {
   count   = local.lambda_enabled && var.forwarder_rds_enabled ? 1 : 0
   source  = "cloudposse/module-artifact/external"
-  version = "0.7.0"
+  version = "0.7.1"
 
   filename    = "forwarder-rds.py"
   module_name = var.dd_module_name

--- a/lambda-vpc-logs.tf
+++ b/lambda-vpc-logs.tf
@@ -22,7 +22,7 @@ module "forwarder_vpclogs_label" {
 module "forwarder_vpclogs_artifact" {
   count   = local.lambda_enabled && var.forwarder_vpc_logs_enabled ? 1 : 0
   source  = "cloudposse/module-artifact/external"
-  version = "0.7.0"
+  version = "0.7.1"
 
   filename    = "lambda_function.py"
   module_name = var.dd_module_name

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,29 +1,29 @@
 output "lambda_forwarder_rds_function_arn" {
   description = "Datadog Lambda forwarder RDS Enhanced Monitoring function ARN"
-  value       = join("", aws_lambda_function.forwarder_rds.*.arn)
+  value       = local.lambda_enabled && var.forwarder_rds_enabled ? join("", aws_lambda_function.forwarder_rds.*.arn) : null
 }
 
 output "lambda_forwarder_rds_enhanced_monitoring_function_name" {
   description = "Datadog Lambda forwarder RDS Enhanced Monitoring function name"
-  value       = join("", aws_lambda_function.forwarder_rds.*.function_name)
+  value       = local.lambda_enabled && var.forwarder_rds_enabled ? join("", aws_lambda_function.forwarder_rds.*.function_name) : null
 }
 
 output "lambda_forwarder_log_function_arn" {
   description = "Datadog Lambda forwarder CloudWatch/S3 function ARN"
-  value       = join("", aws_lambda_function.forwarder_log.*.arn)
+  value       = local.lambda_enabled && var.forwarder_log_enabled ? join("", aws_lambda_function.forwarder_log.*.arn) : null
 }
 
 output "lambda_forwarder_log_function_name" {
   description = "Datadog Lambda forwarder CloudWatch/S3 function name"
-  value       = join("", aws_lambda_function.forwarder_log.*.function_name)
+  value       = local.lambda_enabled && var.forwarder_log_enabled ? join("", aws_lambda_function.forwarder_log.*.function_name) : null
 }
 
 output "lambda_forwarder_vpc_log_function_arn" {
   description = "Datadog Lambda forwarder VPC Flow Logs function ARN"
-  value       = join("", aws_lambda_function.forwarder_vpclogs.*.arn)
+  value       = local.lambda_enabled && var.forwarder_vpc_logs_enabled ? join("", aws_lambda_function.forwarder_vpclogs.*.arn) : null
 }
 
 output "lambda_forwarder_vpc_log_function_name" {
   description = "Datadog Lambda forwarder VPC Flow Logs function name"
-  value       = join("", aws_lambda_function.forwarder_vpclogs.*.function_name)
+  value       = local.lambda_enabled && var.forwarder_vpc_logs_enabled ? join("", aws_lambda_function.forwarder_vpclogs.*.function_name) : null
 }


### PR DESCRIPTION
## what
* Use data source to verify log groups in plan

## why
* Catch it in plan time instead of in apply

## references
* Depends on https://github.com/cloudposse/terraform-external-module-artifact/pull/16

