### PR TITLE
fix(lambda): add variable into Sid name to avoid conflict

### DIFF
--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -114,7 +114,7 @@ resource "aws_lambda_function" "forwarder_log" {
 
 resource "aws_lambda_permission" "allow_s3_bucket" {
   for_each      = local.s3_logs_enabled ? toset(var.s3_buckets) : []
-  statement_id  = "AllowS3ToInvokeLambda"
+  statement_id  = "AllowS3ToInvokeLambda-${each.value}"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.forwarder_log[0].arn
   principal     = "s3.amazonaws.com"


### PR DESCRIPTION
## what
* This PR will fix a bug when more than one bucket is used a log source for Lambda log forwarder

## why
* Currently, when you add a Bucket as log source the Lambda permission Sid statement is "AllowS3ToInvokeLambda"
* When you add a second bucket as log source because the statement is not variabilized, there is a name conflict

## references
* Here is an extract of the traceback when code fails with the current version:

```
Error: Error adding new Lambda Permission for arn:aws:lambda:eu-west-1:xxxxxxxxxxxx:function:datadog-log-forwarder-eu-west-1-logs: ResourceConflictException: The statement id (AllowS3ToInvokeLambda) provided already exists. Please provide a new statement id, or remove the existing statement.
{
  RespMetadata: {
    StatusCode: 409,
    RequestID: "9ced3b6a-6cbe-41ce-8b7c-238697cb4406"
  },
  Message_: "The statement id (AllowS3ToInvokeLambda) provided already exists. Please provide a new statement id, or remove the existing statement.",
  Type: "User"
}
```


