### PR TITLE
Remove use of `lookup` for optional `filter_pattern`

### DIFF
--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -210,5 +210,5 @@ resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_log_subscription_f
   name            = module.forwarder_log_label.id
   log_group_name  = data.aws_cloudwatch_log_group.cloudwatch_log_group[each.key].name
   destination_arn = aws_lambda_function.forwarder_log[0].arn
-  filter_pattern  = lookup(var.cloudwatch_forwarder_log_groups[each.key], "filter_pattern", null)
+  filter_pattern  = each.value.filter_pattern
 }


### PR DESCRIPTION
## What

* Removes an unnecessary use of `lookup` that allows for `filter_pattern` to not exist in log groups.

## Why

* This is leftover from previous behavior where `var.cloudwatch_forwarder_log_groups` was a `map(string)` and not an `object`.

## References

* I proposed moving from a `map` to `object` in #24 to allow structural validation but didn't remove this dynamic access pattern in that PR.
* Where necessary, parsing unknown structures is better handled by [`try`](https://www.terraform.io/language/functions/try), which can wrap property access expressions without modifying their syntax.