### PR TITLE
remove redundant `ignore_changes` for computed attr

### DIFF
--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -108,10 +108,6 @@ resource "aws_lambda_function" "forwarder_log" {
     mode = var.tracing_config_mode
   }
 
-  lifecycle {
-    ignore_changes = [last_modified]
-  }
-
   tags = module.forwarder_log_label.tags
 }
 

--- a/lambda-rds.tf
+++ b/lambda-rds.tf
@@ -103,10 +103,6 @@ resource "aws_lambda_function" "forwarder_rds" {
     mode = var.tracing_config_mode
   }
 
-  lifecycle {
-    ignore_changes = [last_modified]
-  }
-
   tags = module.forwarder_rds_label.tags
 }
 

--- a/lambda-vpc-logs.tf
+++ b/lambda-vpc-logs.tf
@@ -102,10 +102,6 @@ resource "aws_lambda_function" "forwarder_vpclogs" {
     mode = var.tracing_config_mode
   }
 
-  lifecycle {
-    ignore_changes = [last_modified]
-  }
-
   tags = module.forwarder_vpclogs_label.tags
 }
 


### PR DESCRIPTION
## What

* Removes redundant `ignore_changes` blocks for computed attributes, which inherently cannot be user-specified.

## Why

* Terraform prints warnings for redundant `ignore_changes` in 1.2
* In Terraform < 1.2, this was (improperly) reported as drift. This has no direct effect (e.g., triggering an apply) but Terraform does report "Changes made outside Terraform." Many modules, like this one, used `ignore_changes` as a workaround for this drift detection bug, which 1.2 has now fixed.

```
╷
│ Warning: Redundant ignore_changes element
│
│ Adding an attribute name to ignore_changes tells Terraform to ignore future changes to the argument
| in configuration after the object has been created, retaining the value originally configured.
|
│ The attribute modified_at is decided by the provider alone and therefore there can be no configured value to
| compare with. Including this attribute in ignore_changes has no effect. Remove the attribute from
| ignore_changes to quiet this warning.
╵
```

## References

* https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2081
* https://github.com/terraform-aws-modules/terraform-aws-rds/issues/401