### PR TITLE
feat: add functionality to forward Cloudwatch Events

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+---
+name: Bug report
+description: Create a report to help us improve
+labels: ["bug"]
+assignees: [""]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Found a bug?
+        
+        Please checkout our [Slack Community](https://slack.cloudposse.com)
+        or visit our [Slack Archive](https://archive.sweetops.com/).
+
+        [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+
+  - type: textarea
+    id: concise-description
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of what the bug is.
+      placeholder: What is the bug about?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: How do we reproduce it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots or logs to help explain.
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Anything that will help us triage the bug.
+      placeholder: |
+        - OS: [e.g. Linux, OSX, WSL, etc]
+        - Version [e.g. 10.15]
+        - Module version
+        - Terraform version
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: |
+        Add any other context about the problem here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,71 @@
+---
+name: Feature Request
+description: Suggest an idea for this project
+labels: ["feature request"]
+assignees: [""]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question?
+        
+        Please checkout our [Slack Community](https://slack.cloudposse.com)
+        or visit our [Slack Archive](https://archive.sweetops.com/).
+
+        [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+
+  - type: textarea
+    id: concise-description
+    attributes:
+      label: Describe the Feature
+      description: A clear and concise description of what the feature is.
+      placeholder: What is the feature about?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: |
+        Is your feature request related to a problem/challenge you are trying
+        to solve?
+        
+        Please provide some additional context of why this feature or
+        capability will be valuable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: ideal-solution
+    attributes:
+      label: Describe Ideal Solution
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: Alternatives Considered
+      description: Explain alternative solutions or features considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: |
+        Add any other context about the problem here.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,21 @@
 ## what
-* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
-* Use bullet points to be concise and to the point.
+
+<!--
+- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
+- Use bullet points to be concise and to the point.
+-->
 
 ## why
-* Provide the justifications for the changes (e.g. business case). 
-* Describe why these changes were made (e.g. why do these commits fix the problem?)
-* Use bullet points to be concise and to the point.
+
+<!--
+- Provide the justifications for the changes (e.g. business case). 
+- Describe why these changes were made (e.g. why do these commits fix the problem?)
+- Use bullet points to be concise and to the point.
+-->
 
 ## references
-* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
-* Use `closes #123`, if this PR closes a GitHub issue `#123`
 
+<!--
+- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
+- Use `closes #123`, if this PR closes a GitHub issue `#123`
+-->

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -27,7 +27,7 @@ jobs:
             make init
             make github/init/context.tf
             make readme/build
-            echo "::set-output name=create_pull_request::true"
+            echo "create_pull_request=true" >> "$GITHUB_OUTPUT"
           fi
         else
           echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."
@@ -37,7 +37,7 @@ jobs:
       if: steps.update.outputs.create_pull_request == 'true'
       uses: cloudposse/actions/github/create-pull-request@0.30.0
       with:
-        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
         committer: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
         author: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
         commit-message: Update context.tf from origin source

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -19,7 +19,7 @@ jobs:
       if: github.event.pull_request.state == 'open'
       name: Privileged Checkout
       with:
-        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         # Check out the PR commit, not the merge commit
         # Use `ref` instead of `sha` to enable pushing back to `ref`
@@ -30,7 +30,7 @@ jobs:
       if: github.event.pull_request.state == 'open'
       shell: bash
       env:
-        GITHUB_TOKEN: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
+        GITHUB_TOKEN: "${{ secrets.REPO_ACCESS_TOKEN }}"
       run: make BUILD_HARNESS_PATH=/build-harness PACKAGES_PREFER_HOST=true -f /build-harness/templates/Makefile.build-harness pr/auto-format/host
 
     # Commit changes (if any) to the PR branch
@@ -54,10 +54,10 @@ jobs:
           [[ $SENDER ==  "cloudpossebot" ]] || git push
           # Set status to fail, because the push should trigger another status check,
           # and we use success to indicate the checks are finished.
-          printf "::set-output name=%s::%s\n" "changed" "true"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
           exit 1
         else
-          printf "::set-output name=%s::%s\n" "changed" "false"
+          echo "changed=false" >> "$GITHUB_OUTPUT"
           echo "No changes detected"
         fi
 
@@ -75,7 +75,7 @@ jobs:
         contains(' 37929162 29139614 11232728 ', format(' {0} ', github.event.pull_request.user.id))
         && steps.commit.outputs.changed == 'false' && github.event.pull_request.state == 'open'
       with:
-        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
         repository: cloudposse/actions
         event-type: test-command
         client-payload: |-

--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -29,7 +29,7 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       run: |
         default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
-        printf "::set-output name=defaultBranch::%s\n" "${default_branch}"
+        echo "defaultBranch=${default_branch}" >> "$GITHUB_OUTPUT"
         printf "defaultBranchRef.name=%s\n" "${default_branch}"
 
     - name: Update readme
@@ -52,7 +52,7 @@ jobs:
       # If a PR of the auto-update/readme branch is open, this action will just update it, not create a new PR.
       uses: cloudposse/actions/github/create-pull-request@0.30.0
       with:
-        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
         commit-message: Update README.md and docs
         title: Update README.md and docs
         body: |-

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions-ecosystem/action-get-merged-pull-request@v1
         id: get-merged-pull-request
         with:
-          github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          github_token: ${{ secrets.REPO_ACCESS_TOKEN }}
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
         with:
@@ -23,4 +23,4 @@ jobs:
           prerelease: false
           config-name: auto-release.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -11,7 +11,7 @@ jobs:
       - name: "Handle common commands"
         uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
         with:
-          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           repository: cloudposse/actions
           commands: rebuild-readme, terraform-fmt
@@ -26,7 +26,7 @@ jobs:
       - name: "Run tests"
         uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
         with:
-          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           repository: cloudposse/actions
           commands: test

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -21,7 +21,7 @@ jobs:
         checks: "syntax,owners,duppatterns"
         owner_checker_allow_unowned_patterns: "false"
         # GitHub access token is required only if the `owners` check is enabled
-        github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
+        github_access_token: "${{ secrets.REPO_ACCESS_TOKEN }}"
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name != github.repository
       name: "Syntax check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
@@ -223,6 +223,7 @@ Available targets:
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_cloudwatch_event"></a> [cloudwatch\_event](#module\_cloudwatch\_event) | cloudposse/cloudwatch-events/aws | 0.6.1 |
 | <a name="module_forwarder_log_artifact"></a> [forwarder\_log\_artifact](#module\_forwarder\_log\_artifact) | cloudposse/module-artifact/external | 0.7.1 |
 | <a name="module_forwarder_log_label"></a> [forwarder\_log\_label](#module\_forwarder\_log\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_forwarder_log_s3_label"></a> [forwarder\_log\_s3\_label](#module\_forwarder\_log\_s3\_label) | cloudposse/label/null | 0.25.0 |
@@ -257,6 +258,7 @@ Available targets:
 | [aws_lambda_function.forwarder_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function.forwarder_rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function.forwarder_vpclogs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.allow_eventbridge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.allow_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.cloudwatch_enhanced_rds_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.cloudwatch_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
@@ -281,6 +283,7 @@ Available targets:
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_api_key_ssm_arn"></a> [api\_key\_ssm\_arn](#input\_api\_key\_ssm\_arn) | SSM Arn of the Datadog API key, passing this removes the need to fetch the key from the SSM parameter store. This could be the case if the SSM Key is in a different region than the lambda. | `string` | `null` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_cloudwatch_forwarder_event_patterns"></a> [cloudwatch\_forwarder\_event\_patterns](#input\_cloudwatch\_forwarder\_event\_patterns) | Map of title => CloudWatch Event patterns to forward to Datadog. Event structure from here: <https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html#CloudWatchEventsPatterns><br>Example:<pre>hcl<br>cloudwatch_forwarder_event_rules = {<br>  "guardduty" = {<br>    source = ["aws.guardduty"]<br>    detail-type = ["GuardDuty Finding"]<br>  }<br>  "ec2-terminated" = {<br>    source = ["aws.ec2"]<br>    detail-type = ["EC2 Instance State-change Notification"]<br>    detail = {<br>      state = ["terminated"]<br>    }<br>  }<br>}</pre> | <pre>map(object({<br>    version     = optional(list(string))<br>    id          = optional(list(string))<br>    detail-type = optional(list(string))<br>    source      = optional(list(string))<br>    account     = optional(list(string))<br>    time        = optional(list(string))<br>    region      = optional(list(string))<br>    resources   = optional(list(string))<br>    detail      = optional(map(list(string)))<br>  }))</pre> | `{}` | no |
 | <a name="input_cloudwatch_forwarder_log_groups"></a> [cloudwatch\_forwarder\_log\_groups](#input\_cloudwatch\_forwarder\_log\_groups) | Map of CloudWatch Log Groups with a filter pattern that the Lambda forwarder will send logs from. For example: { mysql1 = { name = "/aws/rds/maincluster", filter\_pattern = "" } | <pre>map(object({<br>    name           = string<br>    filter_pattern = string<br>  }))</pre> | `{}` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
 | <a name="input_datadog_forwarder_lambda_environment_variables"></a> [datadog\_forwarder\_lambda\_environment\_variables](#input\_datadog\_forwarder\_lambda\_environment\_variables) | Map of environment variables to pass to the Lambda Function | `map(string)` | `{}` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
@@ -18,6 +18,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_cloudwatch_event"></a> [cloudwatch\_event](#module\_cloudwatch\_event) | cloudposse/cloudwatch-events/aws | 0.6.1 |
 | <a name="module_forwarder_log_artifact"></a> [forwarder\_log\_artifact](#module\_forwarder\_log\_artifact) | cloudposse/module-artifact/external | 0.7.1 |
 | <a name="module_forwarder_log_label"></a> [forwarder\_log\_label](#module\_forwarder\_log\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_forwarder_log_s3_label"></a> [forwarder\_log\_s3\_label](#module\_forwarder\_log\_s3\_label) | cloudposse/label/null | 0.25.0 |
@@ -52,6 +53,7 @@
 | [aws_lambda_function.forwarder_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function.forwarder_rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function.forwarder_vpclogs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.allow_eventbridge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.allow_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.cloudwatch_enhanced_rds_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.cloudwatch_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
@@ -76,6 +78,7 @@
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_api_key_ssm_arn"></a> [api\_key\_ssm\_arn](#input\_api\_key\_ssm\_arn) | SSM Arn of the Datadog API key, passing this removes the need to fetch the key from the SSM parameter store. This could be the case if the SSM Key is in a different region than the lambda. | `string` | `null` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_cloudwatch_forwarder_event_patterns"></a> [cloudwatch\_forwarder\_event\_patterns](#input\_cloudwatch\_forwarder\_event\_patterns) | Map of title => CloudWatch Event patterns to forward to Datadog. Event structure from here: <https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html#CloudWatchEventsPatterns><br>Example:<pre>hcl<br>cloudwatch_forwarder_event_rules = {<br>  "guardduty" = {<br>    source = ["aws.guardduty"]<br>    detail-type = ["GuardDuty Finding"]<br>  }<br>  "ec2-terminated" = {<br>    source = ["aws.ec2"]<br>    detail-type = ["EC2 Instance State-change Notification"]<br>    detail = {<br>      state = ["terminated"]<br>    }<br>  }<br>}</pre> | <pre>map(object({<br>    version     = optional(list(string))<br>    id          = optional(list(string))<br>    detail-type = optional(list(string))<br>    source      = optional(list(string))<br>    account     = optional(list(string))<br>    time        = optional(list(string))<br>    region      = optional(list(string))<br>    resources   = optional(list(string))<br>    detail      = optional(map(list(string)))<br>  }))</pre> | `{}` | no |
 | <a name="input_cloudwatch_forwarder_log_groups"></a> [cloudwatch\_forwarder\_log\_groups](#input\_cloudwatch\_forwarder\_log\_groups) | Map of CloudWatch Log Groups with a filter pattern that the Lambda forwarder will send logs from. For example: { mysql1 = { name = "/aws/rds/maincluster", filter\_pattern = "" } | <pre>map(object({<br>    name           = string<br>    filter_pattern = string<br>  }))</pre> | `{}` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
 | <a name="input_datadog_forwarder_lambda_environment_variables"></a> [datadog\_forwarder\_lambda\_environment\_variables](#input\_datadog\_forwarder\_lambda\_environment\_variables) | Map of environment variables to pass to the Lambda Function | `map(string)` | `{}` | no |

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -12,3 +12,14 @@ dd_api_key_source = {
   resource   = "ssm"
   identifier = "/datadog/datadog_api_key"
 }
+
+cloudwatch_forwarder_event_patterns = {
+  "guardduty" = {
+    source = ["aws.guardduty"]
+    detail-type = ["GuardDuty Finding"]
+  }
+  "cloudtrail" = {
+    source = ["aws.cloudtrail"]
+    detail-type = ["AWS API Call via CloudTrail"]
+  }
+}

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -15,11 +15,11 @@ dd_api_key_source = {
 
 cloudwatch_forwarder_event_patterns = {
   "guardduty" = {
-    source = ["aws.guardduty"]
+    source      = ["aws.guardduty"]
     detail-type = ["GuardDuty Finding"]
   }
   "cloudtrail" = {
-    source = ["aws.cloudtrail"]
+    source      = ["aws.cloudtrail"]
     detail-type = ["AWS API Call via CloudTrail"]
   }
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -27,6 +27,8 @@ module "datadog_lambda_log_forwarder" {
     }
   }
 
+  cloudwatch_forwarder_event_patterns = var.cloudwatch_forwarder_event_patterns
+
   # Supply tags
   # This results in DD_TAGS = "testkey10,testkey3:testval3,testkey4:testval4"
   dd_tags_map = {

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -39,3 +39,37 @@ variable "dd_api_key_source" {
     error_message = "Name for SSM parameter does not appear to be valid format, acceptable characters are `a-zA-Z0-9_.-` and `/` to delineate hierarchies."
   }
 }
+
+variable "cloudwatch_forwarder_event_patterns" {
+  type = map(object({
+    version     = optional(list(string))
+    id          = optional(list(string))
+    detail-type = optional(list(string))
+    source      = optional(list(string))
+    account     = optional(list(string))
+    time        = optional(list(string))
+    region      = optional(list(string))
+    resources   = optional(list(string))
+    detail      = optional(map(list(string)))
+  }))
+  description = <<-EOF
+    Map of title => CloudWatch Event patterns to forward to Datadog. Event structure from here: <https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html#CloudWatchEventsPatterns>
+    Example:
+    ```hcl
+    cloudwatch_forwarder_event_rules = {
+      "guardduty" = {
+        source = ["aws.guardduty"]
+        detail-type = ["GuardDuty Finding"]
+      }
+      "ec2-terminated" = {
+        source = ["aws.ec2"]
+        detail-type = ["EC2 Instance State-change Notification"]
+        detail = {
+          state = ["terminated"]
+        }
+      }
+    }
+    ```
+  EOF
+  default     = {}
+}

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.3.0"
 
   required_providers {
     # Update these to reflect the actual requirements of your module

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -245,7 +245,7 @@ module "cloudwatch_event" {
 
   for_each = local.lambda_enabled && var.forwarder_log_enabled ? var.cloudwatch_forwarder_event_patterns : {}
 
-  name = module.forwarder_log_label.id
+  name = "${module.forwarder_log_label.id}-${each.key}"
 
   cloudwatch_event_rule_description = "${each.key} events forwarded to Datadog"
 

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -248,6 +248,8 @@ module "cloudwatch_event" {
   name = module.forwarder_log_label.id
 
   cloudwatch_event_rule_description = "${each.key} events forwarded to Datadog"
+
+  # Any optional attributes that are not set will equal null, and CloudWatch doesn't like that.
   cloudwatch_event_rule_pattern     = {for k,v in each.value: k => v if v != null}
   cloudwatch_event_target_arn       = aws_lambda_function.forwarder_log[0].arn
 }

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -250,6 +250,6 @@ module "cloudwatch_event" {
   cloudwatch_event_rule_description = "${each.key} events forwarded to Datadog"
 
   # Any optional attributes that are not set will equal null, and CloudWatch doesn't like that.
-  cloudwatch_event_rule_pattern     = {for k,v in each.value: k => v if v != null}
-  cloudwatch_event_target_arn       = aws_lambda_function.forwarder_log[0].arn
+  cloudwatch_event_rule_pattern = { for k, v in each.value : k => v if v != null }
+  cloudwatch_event_target_arn   = aws_lambda_function.forwarder_log[0].arn
 }

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -245,7 +245,8 @@ module "cloudwatch_event" {
 
   for_each = local.lambda_enabled && var.forwarder_log_enabled ? var.cloudwatch_forwarder_event_patterns : {}
 
-  name = "${module.forwarder_log_label.id}-${each.key}"
+  name    = each.key
+  context = module.forwarder_log_label.context
 
   cloudwatch_event_rule_description = "${each.key} events forwarded to Datadog"
 

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -182,14 +182,14 @@ resource "aws_iam_policy" "lambda_forwarder_log_s3" {
   name        = module.forwarder_log_s3_label.id
   path        = var.forwarder_iam_path
   description = "Allow Datadog Lambda Logs Forwarder to access S3 buckets"
-  policy      = join("", data.aws_iam_policy_document.s3_log_bucket.*.json)
+  policy      = join("", data.aws_iam_policy_document.s3_log_bucket[*].json)
   tags        = module.forwarder_log_s3_label.tags
 }
 
 resource "aws_iam_role_policy_attachment" "datadog_s3" {
   count      = local.s3_logs_enabled ? 1 : 0
-  role       = join("", aws_iam_role.lambda_forwarder_log.*.name)
-  policy_arn = join("", aws_iam_policy.lambda_forwarder_log_s3.*.arn)
+  role       = join("", aws_iam_role.lambda_forwarder_log[*].name)
+  policy_arn = join("", aws_iam_policy.lambda_forwarder_log_s3[*].arn)
 }
 
 # Lambda Forwarder logs
@@ -228,4 +228,26 @@ resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_log_subscription_f
   log_group_name  = data.aws_cloudwatch_log_group.cloudwatch_log_group[each.key].name
   destination_arn = aws_lambda_function.forwarder_log[0].arn
   filter_pattern  = each.value.filter_pattern
+}
+
+resource "aws_lambda_permission" "allow_eventbridge" {
+  for_each = local.lambda_enabled && var.forwarder_log_enabled ? var.cloudwatch_forwarder_event_patterns : {}
+
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.forwarder_log[0].function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = module.cloudwatch_event[each.key].aws_cloudwatch_event_rule_arn
+}
+
+module "cloudwatch_event" {
+  source  = "cloudposse/cloudwatch-events/aws"
+  version = "0.6.1"
+
+  for_each = local.lambda_enabled && var.forwarder_log_enabled ? var.cloudwatch_forwarder_event_patterns : {}
+
+  name = module.forwarder_log_label.id
+
+  cloudwatch_event_rule_description = "${each.key} events forwarded to Datadog"
+  cloudwatch_event_rule_pattern     = {for k,v in each.value: k => v if v != null}
+  cloudwatch_event_target_arn       = aws_lambda_function.forwarder_log[0].arn
 }

--- a/main.tf
+++ b/main.tf
@@ -13,13 +13,13 @@ data "aws_region" "current" {
 locals {
   enabled        = module.this.enabled
   arn_format     = local.enabled ? "arn:${data.aws_partition.current[0].partition}" : ""
-  aws_account_id = join("", data.aws_caller_identity.current.*.account_id)
-  aws_region     = join("", data.aws_region.current.*.name)
+  aws_account_id = join("", data.aws_caller_identity.current[*].account_id)
+  aws_region     = join("", data.aws_region.current[*].name)
   lambda_enabled = local.enabled
 
   dd_api_key_resource    = var.dd_api_key_source.resource
   dd_api_key_identifier  = var.dd_api_key_source.identifier
-  dd_api_key_arn         = local.dd_api_key_resource == "ssm" ? coalesce(var.api_key_ssm_arn, join("", data.aws_ssm_parameter.api_key.*.arn)) : local.dd_api_key_identifier
+  dd_api_key_arn         = local.dd_api_key_resource == "ssm" ? coalesce(var.api_key_ssm_arn, join("", data.aws_ssm_parameter.api_key[*].arn)) : local.dd_api_key_identifier
   dd_api_key_iam_actions = [lookup({ kms = "kms:Decrypt", asm = "secretsmanager:GetSecretValue", ssm = "ssm:GetParameter" }, local.dd_api_key_resource, "")]
   dd_api_key_kms         = local.dd_api_key_resource == "kms" ? { DD_KMS_API_KEY = var.dd_api_key_kms_ciphertext_blob } : {}
   dd_api_key_asm         = local.dd_api_key_resource == "asm" ? { DD_API_KEY_SECRET_ARN = local.dd_api_key_identifier } : {}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,29 +1,29 @@
 output "lambda_forwarder_rds_function_arn" {
   description = "Datadog Lambda forwarder RDS Enhanced Monitoring function ARN"
-  value       = local.lambda_enabled && var.forwarder_rds_enabled ? join("", aws_lambda_function.forwarder_rds.*.arn) : null
+  value       = local.lambda_enabled && var.forwarder_rds_enabled ? join("", aws_lambda_function.forwarder_rds[*].arn) : null
 }
 
 output "lambda_forwarder_rds_enhanced_monitoring_function_name" {
   description = "Datadog Lambda forwarder RDS Enhanced Monitoring function name"
-  value       = local.lambda_enabled && var.forwarder_rds_enabled ? join("", aws_lambda_function.forwarder_rds.*.function_name) : null
+  value       = local.lambda_enabled && var.forwarder_rds_enabled ? join("", aws_lambda_function.forwarder_rds[*].function_name) : null
 }
 
 output "lambda_forwarder_log_function_arn" {
   description = "Datadog Lambda forwarder CloudWatch/S3 function ARN"
-  value       = local.lambda_enabled && var.forwarder_log_enabled ? join("", aws_lambda_function.forwarder_log.*.arn) : null
+  value       = local.lambda_enabled && var.forwarder_log_enabled ? join("", aws_lambda_function.forwarder_log[*].arn) : null
 }
 
 output "lambda_forwarder_log_function_name" {
   description = "Datadog Lambda forwarder CloudWatch/S3 function name"
-  value       = local.lambda_enabled && var.forwarder_log_enabled ? join("", aws_lambda_function.forwarder_log.*.function_name) : null
+  value       = local.lambda_enabled && var.forwarder_log_enabled ? join("", aws_lambda_function.forwarder_log[*].function_name) : null
 }
 
 output "lambda_forwarder_vpc_log_function_arn" {
   description = "Datadog Lambda forwarder VPC Flow Logs function ARN"
-  value       = local.lambda_enabled && var.forwarder_vpc_logs_enabled ? join("", aws_lambda_function.forwarder_vpclogs.*.arn) : null
+  value       = local.lambda_enabled && var.forwarder_vpc_logs_enabled ? join("", aws_lambda_function.forwarder_vpclogs[*].arn) : null
 }
 
 output "lambda_forwarder_vpc_log_function_name" {
   description = "Datadog Lambda forwarder VPC Flow Logs function name"
-  value       = local.lambda_enabled && var.forwarder_vpc_logs_enabled ? join("", aws_lambda_function.forwarder_vpclogs.*.function_name) : null
+  value       = local.lambda_enabled && var.forwarder_vpc_logs_enabled ? join("", aws_lambda_function.forwarder_vpclogs[*].function_name) : null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -284,3 +284,37 @@ variable "api_key_ssm_arn" {
   description = "SSM Arn of the Datadog API key, passing this removes the need to fetch the key from the SSM parameter store. This could be the case if the SSM Key is in a different region than the lambda."
   default     = null
 }
+
+variable "cloudwatch_forwarder_event_patterns" {
+  type = map(object({
+    version     = optional(list(string))
+    id          = optional(list(string))
+    detail-type = optional(list(string))
+    source      = optional(list(string))
+    account     = optional(list(string))
+    time        = optional(list(string))
+    region      = optional(list(string))
+    resources   = optional(list(string))
+    detail      = optional(map(list(string)))
+  }))
+  description = <<-EOF
+    Map of title => CloudWatch Event patterns to forward to Datadog. Event structure from here: <https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html#CloudWatchEventsPatterns>
+    Example:
+    ```hcl
+    cloudwatch_forwarder_event_rules = {
+      "guardduty" = {
+        source = ["aws.guardduty"]
+        detail-type = ["GuardDuty Finding"]
+      }
+      "ec2-terminated" = {
+        source = ["aws.ec2"]
+        detail-type = ["EC2 Instance State-change Notification"]
+        detail = {
+          state = ["terminated"]
+        }
+      }
+    }
+    ```
+  EOF
+  default     = {}
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## what
* Enables forwarding of CloudWatch Events to Datadog Logs
* Uses Cloudposse Cloudwatch Events module
* Upgrades tf to >=1.3.0 to enable optionals

## why
* Enables us to get GuardDuty events into DD Logs

