### PR TITLE
add functionality to forward Cloudwatch Events

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -12,3 +12,14 @@ dd_api_key_source = {
   resource   = "ssm"
   identifier = "/datadog/datadog_api_key"
 }
+
+cloudwatch_forwarder_event_patterns = {
+  "guardduty" = {
+    source = ["aws.guardduty"]
+    detail-type = ["GuardDuty Finding"]
+  }
+  "cloudtrail" = {
+    source = ["aws.cloudtrail"]
+    detail-type = ["AWS API Call via CloudTrail"]
+  }
+}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -27,6 +27,8 @@ module "datadog_lambda_log_forwarder" {
     }
   }
 
+  cloudwatch_forwarder_event_patterns = var.cloudwatch_forwarder_event_patterns
+
   # Supply tags
   # This results in DD_TAGS = "testkey10,testkey3:testval3,testkey4:testval4"
   dd_tags_map = {

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -39,3 +39,37 @@ variable "dd_api_key_source" {
     error_message = "Name for SSM parameter does not appear to be valid format, acceptable characters are `a-zA-Z0-9_.-` and `/` to delineate hierarchies."
   }
 }
+
+variable "cloudwatch_forwarder_event_patterns" {
+  type = map(object({
+    version     = optional(list(string))
+    id          = optional(list(string))
+    detail-type = optional(list(string))
+    source      = optional(list(string))
+    account     = optional(list(string))
+    time        = optional(list(string))
+    region      = optional(list(string))
+    resources   = optional(list(string))
+    detail      = optional(map(list(string)))
+  }))
+  description = <<-EOF
+    Map of title => CloudWatch Event patterns to forward to Datadog. Event structure from here: <https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html#CloudWatchEventsPatterns>
+    Example:
+    ```hcl
+    cloudwatch_forwarder_event_rules = {
+      "guardduty" = {
+        source = ["aws.guardduty"]
+        detail-type = ["GuardDuty Finding"]
+      }
+      "ec2-terminated" = {
+        source = ["aws.ec2"]
+        detail-type = ["EC2 Instance State-change Notification"]
+        detail = {
+          state = ["terminated"]
+        }
+      }
+    }
+    ```
+  EOF
+  default     = {}
+}

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.3.0"
 
   required_providers {
     # Update these to reflect the actual requirements of your module

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -248,6 +248,8 @@ module "cloudwatch_event" {
   name = module.forwarder_log_label.id
 
   cloudwatch_event_rule_description = "${each.key} events forwarded to Datadog"
+
+  # Any optional attributes that are not set will equal null, and CloudWatch doesn't like that.
   cloudwatch_event_rule_pattern     = {for k,v in each.value: k => v if v != null}
   cloudwatch_event_target_arn       = aws_lambda_function.forwarder_log[0].arn
 }

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -250,6 +250,6 @@ module "cloudwatch_event" {
   cloudwatch_event_rule_description = "${each.key} events forwarded to Datadog"
 
   # Any optional attributes that are not set will equal null, and CloudWatch doesn't like that.
-  cloudwatch_event_rule_pattern     = {for k,v in each.value: k => v if v != null}
-  cloudwatch_event_target_arn       = aws_lambda_function.forwarder_log[0].arn
+  cloudwatch_event_rule_pattern = { for k, v in each.value : k => v if v != null }
+  cloudwatch_event_target_arn   = aws_lambda_function.forwarder_log[0].arn
 }

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -182,14 +182,14 @@ resource "aws_iam_policy" "lambda_forwarder_log_s3" {
   name        = module.forwarder_log_s3_label.id
   path        = var.forwarder_iam_path
   description = "Allow Datadog Lambda Logs Forwarder to access S3 buckets"
-  policy      = join("", data.aws_iam_policy_document.s3_log_bucket.*.json)
+  policy      = join("", data.aws_iam_policy_document.s3_log_bucket[*].json)
   tags        = module.forwarder_log_s3_label.tags
 }
 
 resource "aws_iam_role_policy_attachment" "datadog_s3" {
   count      = local.s3_logs_enabled ? 1 : 0
-  role       = join("", aws_iam_role.lambda_forwarder_log.*.name)
-  policy_arn = join("", aws_iam_policy.lambda_forwarder_log_s3.*.arn)
+  role       = join("", aws_iam_role.lambda_forwarder_log[*].name)
+  policy_arn = join("", aws_iam_policy.lambda_forwarder_log_s3[*].arn)
 }
 
 # Lambda Forwarder logs
@@ -228,4 +228,26 @@ resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_log_subscription_f
   log_group_name  = data.aws_cloudwatch_log_group.cloudwatch_log_group[each.key].name
   destination_arn = aws_lambda_function.forwarder_log[0].arn
   filter_pattern  = each.value.filter_pattern
+}
+
+resource "aws_lambda_permission" "allow_eventbridge" {
+  for_each = local.lambda_enabled && var.forwarder_log_enabled ? var.cloudwatch_forwarder_event_patterns : {}
+
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.forwarder_log[0].function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = module.cloudwatch_event[each.key].aws_cloudwatch_event_rule_arn
+}
+
+module "cloudwatch_event" {
+  source  = "cloudposse/cloudwatch-events/aws"
+  version = "0.6.1"
+
+  for_each = local.lambda_enabled && var.forwarder_log_enabled ? var.cloudwatch_forwarder_event_patterns : {}
+
+  name = module.forwarder_log_label.id
+
+  cloudwatch_event_rule_description = "${each.key} events forwarded to Datadog"
+  cloudwatch_event_rule_pattern     = {for k,v in each.value: k => v if v != null}
+  cloudwatch_event_target_arn       = aws_lambda_function.forwarder_log[0].arn
 }

--- a/main.tf
+++ b/main.tf
@@ -13,13 +13,13 @@ data "aws_region" "current" {
 locals {
   enabled        = module.this.enabled
   arn_format     = local.enabled ? "arn:${data.aws_partition.current[0].partition}" : ""
-  aws_account_id = join("", data.aws_caller_identity.current.*.account_id)
-  aws_region     = join("", data.aws_region.current.*.name)
+  aws_account_id = join("", data.aws_caller_identity.current[*].account_id)
+  aws_region     = join("", data.aws_region.current[*].name)
   lambda_enabled = local.enabled
 
   dd_api_key_resource    = var.dd_api_key_source.resource
   dd_api_key_identifier  = var.dd_api_key_source.identifier
-  dd_api_key_arn         = local.dd_api_key_resource == "ssm" ? coalesce(var.api_key_ssm_arn, join("", data.aws_ssm_parameter.api_key.*.arn)) : local.dd_api_key_identifier
+  dd_api_key_arn         = local.dd_api_key_resource == "ssm" ? coalesce(var.api_key_ssm_arn, join("", data.aws_ssm_parameter.api_key[*].arn)) : local.dd_api_key_identifier
   dd_api_key_iam_actions = [lookup({ kms = "kms:Decrypt", asm = "secretsmanager:GetSecretValue", ssm = "ssm:GetParameter" }, local.dd_api_key_resource, "")]
   dd_api_key_kms         = local.dd_api_key_resource == "kms" ? { DD_KMS_API_KEY = var.dd_api_key_kms_ciphertext_blob } : {}
   dd_api_key_asm         = local.dd_api_key_resource == "asm" ? { DD_API_KEY_SECRET_ARN = local.dd_api_key_identifier } : {}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,29 +1,29 @@
 output "lambda_forwarder_rds_function_arn" {
   description = "Datadog Lambda forwarder RDS Enhanced Monitoring function ARN"
-  value       = local.lambda_enabled && var.forwarder_rds_enabled ? join("", aws_lambda_function.forwarder_rds.*.arn) : null
+  value       = local.lambda_enabled && var.forwarder_rds_enabled ? join("", aws_lambda_function.forwarder_rds[*].arn) : null
 }
 
 output "lambda_forwarder_rds_enhanced_monitoring_function_name" {
   description = "Datadog Lambda forwarder RDS Enhanced Monitoring function name"
-  value       = local.lambda_enabled && var.forwarder_rds_enabled ? join("", aws_lambda_function.forwarder_rds.*.function_name) : null
+  value       = local.lambda_enabled && var.forwarder_rds_enabled ? join("", aws_lambda_function.forwarder_rds[*].function_name) : null
 }
 
 output "lambda_forwarder_log_function_arn" {
   description = "Datadog Lambda forwarder CloudWatch/S3 function ARN"
-  value       = local.lambda_enabled && var.forwarder_log_enabled ? join("", aws_lambda_function.forwarder_log.*.arn) : null
+  value       = local.lambda_enabled && var.forwarder_log_enabled ? join("", aws_lambda_function.forwarder_log[*].arn) : null
 }
 
 output "lambda_forwarder_log_function_name" {
   description = "Datadog Lambda forwarder CloudWatch/S3 function name"
-  value       = local.lambda_enabled && var.forwarder_log_enabled ? join("", aws_lambda_function.forwarder_log.*.function_name) : null
+  value       = local.lambda_enabled && var.forwarder_log_enabled ? join("", aws_lambda_function.forwarder_log[*].function_name) : null
 }
 
 output "lambda_forwarder_vpc_log_function_arn" {
   description = "Datadog Lambda forwarder VPC Flow Logs function ARN"
-  value       = local.lambda_enabled && var.forwarder_vpc_logs_enabled ? join("", aws_lambda_function.forwarder_vpclogs.*.arn) : null
+  value       = local.lambda_enabled && var.forwarder_vpc_logs_enabled ? join("", aws_lambda_function.forwarder_vpclogs[*].arn) : null
 }
 
 output "lambda_forwarder_vpc_log_function_name" {
   description = "Datadog Lambda forwarder VPC Flow Logs function name"
-  value       = local.lambda_enabled && var.forwarder_vpc_logs_enabled ? join("", aws_lambda_function.forwarder_vpclogs.*.function_name) : null
+  value       = local.lambda_enabled && var.forwarder_vpc_logs_enabled ? join("", aws_lambda_function.forwarder_vpclogs[*].function_name) : null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -284,3 +284,37 @@ variable "api_key_ssm_arn" {
   description = "SSM Arn of the Datadog API key, passing this removes the need to fetch the key from the SSM parameter store. This could be the case if the SSM Key is in a different region than the lambda."
   default     = null
 }
+
+variable "cloudwatch_forwarder_event_patterns" {
+  type = map(object({
+    version     = optional(list(string))
+    id          = optional(list(string))
+    detail-type = optional(list(string))
+    source      = optional(list(string))
+    account     = optional(list(string))
+    time        = optional(list(string))
+    region      = optional(list(string))
+    resources   = optional(list(string))
+    detail      = optional(map(list(string)))
+  }))
+  description = <<-EOF
+    Map of title => CloudWatch Event patterns to forward to Datadog. Event structure from here: <https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html#CloudWatchEventsPatterns>
+    Example:
+    ```hcl
+    cloudwatch_forwarder_event_rules = {
+      "guardduty" = {
+        source = ["aws.guardduty"]
+        detail-type = ["GuardDuty Finding"]
+      }
+      "ec2-terminated" = {
+        source = ["aws.ec2"]
+        detail-type = ["EC2 Instance State-change Notification"]
+        detail = {
+          state = ["terminated"]
+        }
+      }
+    }
+    ```
+  EOF
+  default     = {}
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## what
* Enables forwarding of CloudWatch Events to Datadog Logs
* Uses Cloudposse Cloudwatch Events module
* Upgrades tf to >=1.3.0 to enable optionals

## why
* Enables us to get GuardDuty events into DD Logs

