### PR TITLE
fix: drop statement_id. Low value and has issues

### DIFF
--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -122,7 +122,6 @@ resource "aws_lambda_function" "forwarder_log" {
 resource "aws_lambda_permission" "allow_s3_bucket" {
   for_each = local.s3_logs_enabled ? local.s3_bucket_names_to_authorize : []
 
-  statement_id  = "AllowS3ToInvokeLambda-${each.value}"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.forwarder_log[0].arn
   principal     = "s3.amazonaws.com"


### PR DESCRIPTION
## what

- remove the `statement_id` from the `aws_lambda_permission` resource for
buckets

## why

- `statement_id` breaks when valid buckets are specified. The two have entirely
different requirements for what is syntactically valid
- `statement_id` is intended for organizing many documents. Since the
permission is simple and its intent direct... the parameter is unneeded
- The alternative, to devise a way to correct valid bucket names, is more
logic to maintain and could end up breaking again in the future.

## references

- [statement_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission#statement_id)
- [SweetOps thread](https://sweetops.slack.com/archives/CDYGZCLDQ/p1694455283440709) (Public slack)
