### PR TITLE
feat(log-forwarder): enable cache bucket for failed log events and dd tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 # Crash log files
 crash.log
 test.log
+
+# Downloaded lambda artifact
+forwarder-log.zip

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -259,3 +259,17 @@ module "cloudwatch_event" {
   cloudwatch_event_rule_pattern = { for k, v in each.value : k => v if v != null }
   cloudwatch_event_target_arn   = aws_lambda_function.forwarder_log[0].arn
 }
+
+//trunk-ignore(checkov/CKV_TF_1)
+module "tags_cache_s3_bucket" {
+  # Bucket for storing lambda tags cache and logs which failed to post. https://docs.datadoghq.com/logs/guide/forwarder/?tab=cloudformation#upgrade-an-older-version-to-31060
+  source  = "cloudposse/s3-bucket/aws"
+  version = "4.2.0"
+
+  count = local.lambda_enabled && var.forwarder_use_cache_bucket ? 1 : 0
+
+  name    = "${module.forwarder_log_label.id}-cache"
+  context = module.forwarder_log_label.context
+
+
+}

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -285,6 +285,7 @@ module "tags_cache_s3_bucket" {
 
   count = local.lambda_enabled && var.forwarder_use_cache_bucket ? 1 : 0
 
-  name    = "${module.forwarder_log_label.id}-cache"
+  attributes = concat(module.forwarder_log_label.attributes, ["cache"])
+
   context = module.forwarder_log_label.context
 }

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ locals {
   ] : var.dd_tags
   dd_tags_env = { DD_TAGS = join(",", local.dd_tags) }
 
-  cache_bucket_env = var.forwarder_use_cache_bucket ? { DD_S3_BUCKET_NAME = module.tags_cache_s3_bucket.name } : {}
+  cache_bucket_env = var.forwarder_use_cache_bucket ? { DD_S3_BUCKET_NAME = one(module.tags_cache_s3_bucket[*].bucket_id), DD_STORE_FAILED_EVENTS = true } : {}
 
   lambda_debug = var.forwarder_lambda_debug_enabled ? { DD_LOG_LEVEL = "debug" } : {}
   lambda_env   = merge(local.dd_api_key_kms, local.dd_api_key_asm, local.dd_api_key_ssm, local.dd_site, local.lambda_debug, local.dd_tags_env, local.cache_bucket_env, var.datadog_forwarder_lambda_environment_variables)

--- a/main.tf
+++ b/main.tf
@@ -36,8 +36,10 @@ locals {
   ] : var.dd_tags
   dd_tags_env = { DD_TAGS = join(",", local.dd_tags) }
 
+  cache_bucket_env = var.forwarder_use_cache_bucket ? { DD_S3_BUCKET_NAME = module.tags_cache_s3_bucket.name } : {}
+
   lambda_debug = var.forwarder_lambda_debug_enabled ? { DD_LOG_LEVEL = "debug" } : {}
-  lambda_env   = merge(local.dd_api_key_kms, local.dd_api_key_asm, local.dd_api_key_ssm, local.dd_site, local.lambda_debug, local.dd_tags_env, var.datadog_forwarder_lambda_environment_variables)
+  lambda_env   = merge(local.dd_api_key_kms, local.dd_api_key_asm, local.dd_api_key_ssm, local.dd_site, local.lambda_debug, local.dd_tags_env, local.cache_bucket_env, var.datadog_forwarder_lambda_environment_variables)
 }
 
 # Log Forwarder, RDS Enhanced Forwarder, VPC Flow Log Forwarder

--- a/variables.tf
+++ b/variables.tf
@@ -105,7 +105,7 @@ variable "dd_module_name" {
 variable "dd_forwarder_version" {
   type        = string
   description = "Version tag of Datadog lambdas to use. https://github.com/DataDog/datadog-serverless-functions/releases"
-  default     = "3.39.0"
+  default     = "3.116.0"
 }
 
 variable "forwarder_log_enabled" {
@@ -327,4 +327,10 @@ variable "cloudwatch_forwarder_event_patterns" {
     ```
   EOF
   default     = {}
+}
+
+variable "forwarder_use_cache_bucket" {
+  type        = bool
+  description = "Flag to enable or disable the cache bucket for lambda tags and failed events. See https://docs.datadoghq.com/logs/guide/forwarder/?tab=cloudformation#upgrade-an-older-version-to-31060. Recommended for forwarder versions 3.106 and higher."
+  default     = true
 }


### PR DESCRIPTION
## what

Creates a bucket for storing Datadog Lambda tag cache (I'm not sure what this actually is) and storing log events which the lambda failed to post to DD.

See info [here](https://docs.datadoghq.com/logs/guide/forwarder/?tab=cloudformation#upgrade-an-older-version-to-31060) and [here](https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring#manual)

## why

We upgraded our lambda to the latest version published by DD and were receiving errors because DD_S3_BUCKET was unset, I investigated this functionality and implemented it in this module.
