### PR TITLE
Manage forwarded log group

### DIFF
--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -216,7 +216,7 @@ resource "aws_cloudwatch_log_group" "forwarder_log" {
 }
 
 resource "aws_cloudwatch_log_group" "cloudwatch_log_group" {
-  for_each = local.lambda_enabled && var.forwarder_log_enabled ? var.cloudwatch_forwarder_log_groups : {}
+  for_each = local.lambda_enabled && var.forwarder_log_enabled && var.cloudwatch_create_log_groups_enabled ? var.cloudwatch_forwarder_log_groups : {}
 
   name              = each.value.name
   retention_in_days = var.forwarder_log_retention_days
@@ -242,7 +242,7 @@ resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_log_subscription_f
   log_group_name  = each.value.name
   destination_arn = aws_lambda_function.forwarder_log[0].arn
   filter_pattern  = each.value.filter_pattern
-  depends_on = [ aws_cloudwatch_log_group.cloudwatch_log_group ]
+  depends_on      = [ aws_cloudwatch_log_group.cloudwatch_log_group ]
 }
 
 resource "aws_lambda_permission" "allow_eventbridge" {

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -242,6 +242,7 @@ resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_log_subscription_f
   log_group_name  = each.value.name
   destination_arn = aws_lambda_function.forwarder_log[0].arn
   filter_pattern  = each.value.filter_pattern
+  depends_on = [ aws_cloudwatch_log_group.cloudwatch_log_group ]
 }
 
 resource "aws_lambda_permission" "allow_eventbridge" {

--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -215,6 +215,15 @@ resource "aws_cloudwatch_log_group" "forwarder_log" {
   tags = module.forwarder_log_label.tags
 }
 
+resource "aws_cloudwatch_log_group" "cloudwatch_log_group" {
+  for_each = local.lambda_enabled && var.forwarder_log_enabled ? var.cloudwatch_forwarder_log_groups : {}
+
+  name              = each.value.name
+  retention_in_days = var.forwarder_log_retention_days
+
+  tags = module.forwarder_log_label.tags
+}
+
 # CloudWatch Log Groups
 resource "aws_lambda_permission" "cloudwatch_groups" {
   for_each = local.lambda_enabled && var.forwarder_log_enabled ? var.cloudwatch_forwarder_log_groups : {}

--- a/variables.tf
+++ b/variables.tf
@@ -167,6 +167,12 @@ variable "cloudwatch_forwarder_log_groups" {
   default     = {}
 }
 
+variable "cloudwatch_create_log_groups_enabled" {
+  type        = bool
+  description = "Whether to create the CloudWatch Log Groups that are being forwarded to Datadog"
+  default     = false
+}
+
 variable "forwarder_lambda_debug_enabled" {
   type        = bool
   description = "Whether to enable or disable debug for the Lambda forwarder"


### PR DESCRIPTION
## what

- Add variable to enable or disable the module to manage the cloudwatch forwarder log groups, default to false to keep current behavior
- Create each of the forwarder log groups in the map
- Ensure the log groups are created before the subscription filter is created, which requires the log group to alread exist

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

- Subscription filters require log groups to exist
- One main reason for using forwarders is to support non-native library support for forwarding logs. Datadog Forwarder is recommended for use with Lambda@Edge, but Lambda@Edge creates the log groups on the fly for each AWS region.

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

References to Datadog's native lambda not supporting log forwarding for Lambda@Edge
- https://github.com/DataDog/datadog-lambda-js/issues/102
- https://github.com/DataDog/datadog-serverless-functions/issues/359
<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
