### PR TITLE
add permission needed by datadog for cache bucket

### DIFF
--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -196,6 +196,7 @@ data "aws_iam_policy_document" "s3_log_bucket" {
         "s3:PutObject",
         "s3:ListObject",
         "s3:DeleteObject",
+        "s3:ListBucket",
       ]
       resources = [
         one(module.tags_cache_s3_bucket[*].bucket_arn),


### PR DESCRIPTION
## what

We are seeing security signals from Datadog indicating `s3:ListBucket` is needed by the cache bucket created by `module "tags_cache_s3_bucket" {}`.
```
User: arn:aws:sts::*********:assumed-role/dev-global-datadog-logs/dev-global-datadog-logs is not authorized to perform: s3:ListBucket on resource: "arn:aws:s3:::dev-global-datadog-logs-cache" because no identity-based policy allows the s3:ListBucket action
```

## why

Ensure Datadog has permissions needed.

