### PR TITLE
Finer Controls for S3 Events Notifications

### DIFF
--- a/lambda-log.tf
+++ b/lambda-log.tf
@@ -136,7 +136,7 @@ resource "aws_s3_bucket_notification" "s3_bucket_notification" {
 
   lambda_function {
     lambda_function_arn = aws_lambda_function.forwarder_log[0].arn
-    events              = ["s3:ObjectCreated:*"]
+    events              = var.s3_notification_events
   }
 
   depends_on = [aws_lambda_permission.allow_s3_bucket]
@@ -149,7 +149,7 @@ resource "aws_s3_bucket_notification" "s3_bucket_notification_with_prefixes" {
 
   lambda_function {
     lambda_function_arn = aws_lambda_function.forwarder_log[0].arn
-    events              = ["s3:ObjectCreated:*"]
+    events              = var.s3_notification_events
     filter_prefix       = each.value.bucket_prefix
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -340,3 +340,9 @@ variable "forwarder_use_cache_bucket" {
   description = "Flag to enable or disable the cache bucket for lambda tags and failed events. See https://docs.datadoghq.com/logs/guide/forwarder/?tab=cloudformation#upgrade-an-older-version-to-31060. Recommended for forwarder versions 3.106 and higher."
   default     = true
 }
+
+variable "s3_notification_events" {
+  type        = list(string)
+  description = "List of S3 events to trigger the Lambda notification"
+  default     = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -344,5 +344,5 @@ variable "forwarder_use_cache_bucket" {
 variable "s3_notification_events" {
   type        = list(string)
   description = "List of S3 events to trigger the Lambda notification"
-  default     = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+  default     = ["s3:ObjectCreated:*"]
 }


### PR DESCRIPTION
## what
Introduce a new variable to have a fine-grained control about the type of S3 Events to trigger the Lambda Notification

## why
Default should capture all the Create and Removal events (safer and more compreensive)
AND the variable would provide flexibility to include / remove as needed by users.

## references
N/A